### PR TITLE
Factor out guests from sample Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .inventory
 .ssh-config
 .vagrant
+GUESTS.rb
 Vagrantfile
 ansible.cfg

--- a/GUESTS.rb.sample
+++ b/GUESTS.rb.sample
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# List guests here, one per record.
+# name: (REQUIRED), name of the box
+# box: (optional), box to build from. Default DEFAULT_BOX
+# ip: (optional), IP address for local networking. Can be full dotted quad,
+#     the last octet, which will be appended to the IP_NETWORK environmental
+#     variabl, or 'dhcp'. Default none.
+# ports: (optional), Array of ports to forward. Can either be integers, or a
+#     hash with supported options. Default none (ssh only)
+# sync: (optional) Should /vagrant be mounted? Default false
+# update: (optional) Updates all pacakges. Default false
+# needs_python: (optional) Install python packages? Default false
+#     (Debian/Ubuntu only)
+# If there are multiple systems, the first one will be marked "primary"
+
+GUESTS = [
+  { name: 'default' },
+  #{ name: 'web1', box: 'centos/6', ip: '2' },
+  #{ name: 'web2', ip: '192.168.1.3' },
+  #{ name: 'db1' },
+  #{ name: 'app', sync: true, ports: [ 8088, { guest: 80, host: 8000 } ] },
+  #{ name: 'datastore', box: 'ubuntu/xenial64', needs_python: true },
+]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # Vagrant as Infrastructure
 
-
 Inspired by Maxim Chernyak's blog post [6 practices for super smooth Ansible experience](http://hakunin.com/six-ansible-practices).
 
 The goal is to produce the convenient local playground, but skipping the ssh key insertion (Vagrant does that for us) and editing /etc/hosts (not available on Windows) but still allowing full access to the guest VMs.
 
+## Requirements:
+
+* GNU Make
+* Vagrant
+* A provider (VirtualBox, VMware, etc)
+
 ## Method:
 
-* Requires a `Vagrantfile` that creates the application stack systems
-  See `Vagrant.sample` for a starting point.
+* Uses a provided or downloaded `Vagrantfile` to create the application stack systems.
+  See `Vagrantfile.sample` for a starting point.
 * Install any required Galaxy roles (optional)
-* Write out the ssh configuration (provided by Vagrant)
-* Create an `ansible.cfg` that uses the above ssh configuration
-* Prints out the private IP address of the VMs
+* Write the ssh configuration (as provided by Vagrant)
+* Creates `ansible.cfg` that uses the above ssh configuration
+* Displays the IP address of the VMs
 
 ## Roles
 
 If `roles.yml` or `config/roles.yml` exists, the listed roles will be downloaded from Galaxy. If both exist, then `roles.yml` will take precedence.
+
+## Caveats:
+
+The `clean-roles` target will clean _all_ the roles, even ones manually installed.
+
+The `ip` target may fail on non-Linux guests.

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -5,32 +5,11 @@
 IP_NETWORK=ENV.fetch('IP_NETWORK','172.16.1')
 DEFAULT_BOX=ENV.fetch('DEFAULT_BOX', 'centos/7')
 
-# List guests here, one per record.
-# name: (REQUIRED) name of the box
-# box: (optional) box to build from. Default DEFAULT_BOX
-# ip: (optional) IP address for local networking. Can be full dotted quad
-#     or the last octet, which will be appended to the IP_NETWORK environmental
-#     variable. Special value 'dhcp' can be used. Default none
-# ports: (optional) Array of ports to forward. Can either be integers, or a
-#     hash with supported options. Default no forwarded ports
-# cpus: (optional) number of CPUs to assign the VM. Default provider specific
-# memory: (optional) RAM to assign in KB. Default provider specific
-# gui: (optional), Enable GUI. Default false
-# sync: (optional) Should /vagrant be mounted? Default false
-# needs_python: (optional) Install python packages? Default false
-#     (Debian/Ubuntu only)
-# If there are multiple systems, the first one will be marked "primary"
-guests = [
-  { name: 'default' },
-  #{ name: 'web1', box: 'centos/6', ip: '2' },
-  #{ name: 'web2', ip: '192.168.1.3' },
-  #{ name: 'db1' },
-  #{ name: 'app', sync: true, ports: [ 8088, { guest: 80, host: 8000 } ] },
-  #{ name: 'datastore', box: 'ubuntu/xenial64', needs_python: true },
-]
+# List guests separately
+require_relative 'GUESTS';
 
 Vagrant.configure(2) do |config|
-  guests.each_with_index do |guest, i|
+  GUESTS.each_with_index do |guest, i|
     config.vm.define "#{guest[:name]}", primary: i==0 do |box|
       box.vm.box_check_update = false
       # OS
@@ -89,6 +68,21 @@ Vagrant.configure(2) do |config|
             export DEBIAN_FRONTEND=noninteractive
             apt-get update  --quiet=2
             apt-get install --quiet=2 --option=Dpkg::Use-Pty=0 --assume-yes python python-apt
+          SCRIPT
+      end
+      if guest.has_key?(:update) && guest[:update]
+        box.vm.provision 'shell',
+          inline: <<-'SCRIPT'
+            if command -v apt-get > /dev/null; then
+              export DEBIAN_FRONTEND=noninteractive
+              echo apty
+              apt-get update  --quiet=2
+              apt-get upgrade --quiet=2 --option=Dpkg::Use-Pty=0 --assume-yes
+            fi
+            if command -v yum > /dev/null; then
+              yum upgrade --quiet --assumeyes
+              echo yummy
+            fi
           SCRIPT
       end
     end


### PR DESCRIPTION
Solves a problem of being difficult to update Vagrantfile

Only downloads current version of referenced files
Normalised echo calls
Most files are by overrideable variable names
Generated files are now hidden by default
GUESTS supports update flag