### PR TITLE
Support libvirt provider

### DIFF
--- a/README-libvirt.md
+++ b/README-libvirt.md
@@ -1,0 +1,46 @@
+# Installing Libvirt/Qemu
+
+On Arch linux, and hopefully most systemd-based Linux distributions, the following steps were necessary in preparation
+to install the vagrant libvirt plugin.
+
+The majority of this information was taken from the [Arch Wiki][libvirt-arch] entry on Libvirt.
+
+## Verify KVM support
+While not mandatory, we want to use KVM as the hypervisor for libvirt/Qemu
+```
+lsmod | grep kvm
+```
+If this command returns nothing, you may have to manually load the module in the kernel.
+
+## Packages
+This installs what I believe to be the core packages necessary for using libvirt/qemu.
+```
+sudo pacman -Suy libvirt qemu firewalld ebtables dnsmasq bridge-utils openbsd-netcat
+```
+
+## Configuration
+The firewalld configuration file needed to be updated to use iptables.
+```
+vi /etc/firewalld/firewalld.conf
+# Last line (change FirewallBackend to iptables from nftables)
+```
+
+## Add user to libvirt group
+This allows for passwordless access to the libvirt RW daemon socket
+```
+sudo usermod -a -G libvirt <user>
+```
+
+## SystemD
+```
+sudo systemctl enable libvirtd.service
+sudo systemctl start libvirtd.service virtlogd.service
+```
+
+## Install libvirt plugin
+```
+vagrant plugin install vagrant-libvirt
+```
+
+[libvirt-arch]:https://wiki.archlinux.org/index.php/Libvirt
+

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -59,7 +59,7 @@ Vagrant.configure(2) do |config|
       end
       box.vm.provider "libvirt" do |v|
         v.cpus            = guest[:cpus]   if guest.has_key?(:cpus)
-        v.graphics_type   = guest[:gui]    if guest.has_key?(:gui)
+        v.graphics_type   = 'sdl'          if guest.has_key?(:gui)
         v.memory          = guest[:memory] if guest.has_key?(:memory)
       end
       config.vm.provider "vmware_fusion" do |v|

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -57,6 +57,11 @@ Vagrant.configure(2) do |config|
         v.gui    = guest[:gui]    if guest.has_key?(:gui)
         v.memory = guest[:memory] if guest.has_key?(:memory)
       end
+      box.vm.provider "libvirt" do |v|
+        v.cpus            = guest[:cpus]   if guest.has_key?(:cpus)
+        v.graphics_type   = guest[:gui]    if guest.has_key?(:gui)
+        v.memory          = guest[:memory] if guest.has_key?(:memory)
+      end
       config.vm.provider "vmware_fusion" do |v|
         v.gui             = guest[:gui]    if guest.has_key?(:gui)
         v.vmx["memsize"]  = guest[:memory] if guest.has_key?(:memory)


### PR DESCRIPTION
Fixes #15 
I suspect there may be some issues with more nuanced networking options. But some initial 'simple' tests using this Vagrantfile with the centos/7 libvirt box seems to work as expected. The `gui`/`graphics_type` option is probably not ideal. And I'm not sure when/how it's relevant. So perhaps we can discuss that one more.

## Proposed Changes
  - Add libvirt provider to sample Vagrantfile
  - Add README for libvirt installation/configuration

## Checklist

[ ] Version updated (major/minor/patch)
[ ] CHANGELOG updated
[ ] README/Makefile is consistent
