### PR TITLE
Bump up VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ROLES_PATH ?= roles
 SAMPLEVAGRANTFILE ?= $(REPO)/$(VERSION)/Vagrantfile.sample
 SSHCONFIG ?= .ssh-config
 VAULTPASSWORDFILE ?= .vaultpassword
-VERSION := 1.1.0
+VERSION := 1.2.0
 WHOAMI := $(lastword $(MAKEFILE_LIST))
 .PHONY: menu \
 	all \


### PR DESCRIPTION
Makefile didn't change, but the Vagrantfile.sample/GUESTS.rb.sample
did. Bumping VERSION allows the updated files to be pulled.

I kinda forgot that Makefile pulls from the exact version.. oops.

Fixes #

## Proposed Changes

  -
  -
  -

## Checklist

[ ] Version updated (major/minor/patch)
[ ] CHANGELOG updated
[ ] README/Makefile is consistent
