### PR TITLE
Factor provider specification to per Vagrantfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2019-12-05
+### Fixed
+- Provider can be only per vagrant up invocation
+
+## [1.2.0] - 2019-12-04
+### Added
+- Per machine selectable provider
+- Support Parallels as a provider
+
 ## [1.1.0] - 2018-10-18
 ### Added
 - `file`, `shell`, and `ansible` provisioners in Vagrantfile/GUESTS.rb

--- a/GUESTS.rb.sample
+++ b/GUESTS.rb.sample
@@ -25,7 +25,14 @@
 # file: Filename (or array of filenames) to supply to file provisioner
 # shell: Script (or array of scripts) to supply to shell provisioner
 
+# PROVIDER:
+# Select the provider to use. This is a global, it can be set only once per
+# vagrant up invocation. Command line will override this value.
+# Default virtualbox or $VAGRANT_DEFAULT_PROVIDER
+
 # If there are multiple guests, the first one will be marked "primary"
+
+PROVIDER = 'virtualbox'
 
 GUESTS = [
   { name: 'default' },

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ROLES_PATH ?= roles
 SAMPLEVAGRANTFILE ?= $(REPO)/$(VERSION)/Vagrantfile.sample
 SSHCONFIG ?= .ssh-config
 VAULTPASSWORDFILE ?= .vaultpassword
-VERSION := 1.2.0
+VERSION := 1.3.0
 WHOAMI := $(lastword $(MAKEFILE_LIST))
 .PHONY: menu \
 	all \

--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ Options are:
   - id: (string) friendly name (default _nil_)
   - protocol: (string) tcp or udp (default _nil_)
   - default _nil_
-- provisioner: (string) Name of provisioner to use (default virtualbox or
-  _VAGRANT_DEFAULT_PROVIDER_)
 - sync: (boolean) Sync local folder to guest (default _false_)
 - update: (boolean) Update guest OS packages (default _false_)
 _Available provisioners_
@@ -148,6 +146,8 @@ _Available provisioners_
 - shell: (string|array of strings) script to run at provisioning
   - can be an array, for multiple shell provisioners
   - default _nil_
+
+Setting `PROVIDER` will set the provider for all guests.
 
 See [GUESTS.rb.sample][G] for examples.
 

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -10,6 +10,14 @@ _DEFAULT_PROVIDER=ENV.fetch('VAGRANT_DEFAULT_PROVIDER', 'virtualbox')
 require_relative 'GUESTS';
 
 Vagrant.configure(2) do |config|
+
+  # Provider
+  if defined?(PROVIDER)
+    config.vm.provider "#{PROVIDER}"
+  else
+    config.vm.provider "#{_DEFAULT_PROVIDER}"
+  end
+
   GUESTS.each_with_index do |guest, i|
     config.vm.define "#{guest[:name]}", primary: i==0 do |box|
       box.vm.box_check_update = false
@@ -60,14 +68,7 @@ Vagrant.configure(2) do |config|
         end
       end
 
-      # :provider Provider
-      if guest.has_key?(:provider)
-        box.vm.provider "#{guest[:provider]}"
-      else
-        box.vm.provider "#{_DEFAULT_PROVIDER}"
-      end
-
-      #  :cpus/:gui:/:memory CPU / GUI / RAM
+      # :cpus/:gui:/:memory CPU / GUI / RAM
       box.vm.provider "virtualbox" do |v|
         v.cpus   = guest[:cpus]   if guest.has_key?(:cpus)
         v.gui    = guest[:gui]    if guest.has_key?(:gui)


### PR DESCRIPTION
Vagrant does not, at this time, support setting per-guest providers
in a single invocation. Factoring out provider as a global prevents
the inherent confusion that would ensue

## Checklist

[x] Version updated (major/minor/patch)
[x] CHANGELOG updated
[x] README/Makefile is consistent
