### PR TITLE
Define mem/cpu/gui per machine for all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2019-12-05
+### Fixed
+- Machine settings are per-machine for all providers
+
 ## [1.3.0] - 2019-12-05
 ### Fixed
 - Provider can be only per vagrant up invocation

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ROLES_PATH ?= roles
 SAMPLEVAGRANTFILE ?= $(REPO)/$(VERSION)/Vagrantfile.sample
 SSHCONFIG ?= .ssh-config
 VAULTPASSWORDFILE ?= .vaultpassword
-VERSION := 1.3.0
+VERSION := 1.3.1
 WHOAMI := $(lastword $(MAKEFILE_LIST))
 .PHONY: menu \
 	all \

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -74,19 +74,19 @@ Vagrant.configure(2) do |config|
         v.gui    = guest[:gui]    if guest.has_key?(:gui)
         v.memory = guest[:memory] if guest.has_key?(:memory)
       end
-      config.vm.provider "parallels" do |v|
+      box.vm.provider "parallels" do |v|
         v.cpus   = guest[:cpus]   if guest.has_key?(:cpus)
         if guest.has_key?(:gui)
           v.customize ["set", :id, "--startup-view", guest[:gui] ? "window" : "headless"]
         end
         v.memory = guest[:memory] if guest.has_key?(:memory)
       end
-      config.vm.provider "vmware_fusion" do |v|
+      box.vm.provider "vmware_fusion" do |v|
         v.vmx["numvcpus"] = guest[:cpus]   if guest.has_key?(:cpus)
         v.gui             = guest[:gui]    if guest.has_key?(:gui)
         v.vmx["memsize"]  = guest[:memory] if guest.has_key?(:memory)
       end
-      config.vm.provider "vmware_workstation" do |v|
+      box.vm.provider "vmware_workstation" do |v|
         v.vmx["numvcpus"] = guest[:cpus]   if guest.has_key?(:cpus)
         v.gui             = guest[:gui]    if guest.has_key?(:gui)
         v.vmx["memsize"]  = guest[:memory] if guest.has_key?(:memory)


### PR DESCRIPTION
All but virtualbox were setting memory/cpu/gui on a per-run basis
instead of the desired per-machine basis.

Should be fixed now.


## Checklist

[x ] Version updated (major/minor/patch)
[x] CHANGELOG updated
[n/a] README/Makefile is consistent
